### PR TITLE
Socket Holder

### DIFF
--- a/gridfinity_socket_holder.scad
+++ b/gridfinity_socket_holder.scad
@@ -3,34 +3,32 @@ include <gridfinity_modules.scad>
 part = 5;
 
 if (part == 1) {
-	socket_holder(4, [12,12,12,13,14,16,16,17,21,22], "METRIC", stackable=false);
+	socket_holder(4, [12,12,12,13,14,16,16,17,21,22], "METRIC");
 } else if (part == 2) {
-	socket_holder(4, [12,13,14,14,16,16,17,18,20,22], "IMPERIAL", stackable=false);
+	socket_holder(4, [12,13,14,14,16,16,17,18,20,22], "IMPERIAL");
 } else if (part == 3) {
-	socket_holder(4, [12,12,12,12,12,12,13,14,14,16,16], "Imperial < 1/2\"", stackable=true);
+	socket_holder(4, [12,12,12,12,12,12,13,14,14,16,16], "Imperial < 1/2\"", num_z=5);
 } else if (part == 4) {
-	socket_holder(3, [17,18,20,22,24], "Imperial >= 1/2\"", stackable=false);
+	socket_holder(3, [17,18,20,22,24], "Imperial >= 1/2\"");
 } else if (part == 5) {
-	socket_holder(4, [12,12,12,13,14,16,16,17,21,22], "Metric >=7mm", stackable=true);
+	socket_holder(4, [12,12,12,13,14,16,16,17,21,22], "Metric >=7mm", num_z=6);
 } else if (part == 6) {
-	socket_holder(2, [12,12,12,12,12,12], "metric<7mm", stackable=false);
+	socket_holder(2, [12,12,12,12,12,12], "metric<7mm");
 }
 
 function inc(v, a=.6) = [for (i = v) i+a ];
 
-module socket_holder(num_x=1, widths=[], name="", stackable=false) {
+module socket_holder(num_x=1, widths=[], name="", num_z=3) {
 	difference(){
-		grid_block(num_x, 1, stackable ? 5 : 3);
+		grid_block(num_x, 1, num_z);
 		usable_w = 42*num_x - 6;
 		rotate([-45,0,0])translate([-18,-5,1])
-			sockets(inc(widths,0.6), usable_w);
+			#sockets(inc(widths,0.6), usable_w);
 		rotate([-45,0,0])translate([-18,-23-6,5])
 			cube([usable_w,18,26]);
 		translate([-18,-20,10])rotate([90,0,0])
 			linear_extrude(10)text(name);
-		if(stackable){
-			translate([-18,-18,22])cube([usable_w,42-6,14]);
-		}
+		translate([-18,-18,22])cube([usable_w,42-6,50]);
 	}
 }
 

--- a/gridfinity_socket_holder.scad
+++ b/gridfinity_socket_holder.scad
@@ -3,44 +3,49 @@ include <gridfinity_modules.scad>
 part = 5;
 
 if (part == 1) {
-	socket_holder(4, [12,12,12,13,14,16,16,17,21,22], "METRIC");
-} else if (part == 2) {
-	socket_holder(4, [12,13,14,14,16,16,17,18,20,22], "IMPERIAL");
-} else if (part == 3) {
-	socket_holder(4, [12,12,12,12,12,12,13,14,14,16,16], "Imperial < 1/2\"", num_z=5);
-} else if (part == 4) {
-	socket_holder(3, [17,18,20,22,24], "Imperial >= 1/2\"");
-} else if (part == 5) {
-	socket_holder(4, [12,12,12,13,14,16,16,17,21,22], "Metric >=7mm", num_z=6);
-} else if (part == 6) {
-	socket_holder(2, [12,12,12,12,12,12], "metric<7mm");
+  socket_holder(4, [12,12,12,13,14,16,16,17,21,22], "METRIC");
+}
+lse if (part == 2) {
+  socket_holder(4, [12,13,14,14,16,16,17,18,20,22], "IMPERIAL");
+}
+lse if (part == 3) {
+  socket_holder(4, [12,12,12,12,12,12,13,14,14,16,16], "Imperial < 1/2\"", num_z=5);
+}
+else if (part == 4) {
+  socket_holder(3, [17,18,20,22,24], "Imperial >= 1/2\"");
+}
+else if (part == 5) {
+  socket_holder(4, [12,12,12,13,14,16,16,17,21,22], "Metric >=7mm", num_z=6);
+}
+else if (part == 6) {
+  socket_holder(2, [12,12,12,12,12,12], "metric<7mm");
 }
 
 function inc(v, a=.6) = [for (i = v) i+a ];
 
 module socket_holder(num_x=1, widths=[], name="", num_z=3) {
-	difference(){
-		grid_block(num_x, 1, num_z);
-		usable_w = 42*num_x - 6;
-		rotate([-45,0,0])translate([-18,-5,1])
-			#sockets(inc(widths,0.6), usable_w);
-		rotate([-45,0,0])translate([-18,-23-6,5])
-			cube([usable_w,18,26]);
-		translate([-18,-20,10])rotate([90,0,0])
-			linear_extrude(10)text(name);
-		translate([-18,-18,22])cube([usable_w,42-6,50]);
-	}
+  difference() {
+    grid_block(num_x, 1, num_z);
+    usable_w = 42*num_x - 6;
+    rotate([-45,0,0])translate([-18,-5,1])
+      #sockets(inc(widths,0.6), usable_w);
+    rotate([-45,0,0])translate([-18,-23-6,5])
+      cube([usable_w,18,26]);
+    translate([-18,-20,10])rotate([90,0,0])
+      linear_extrude(10)text(name);
+    translate([-18,-18,22])cube([usable_w,42-6,50]);
+  }
 }
 
 function move(v, i=0, r=0, lo=0) = i > 0 ? move(v, i-1, r+(v[i-1]+v[i])/2, lo) + lo : r;
 function sum(v, i=0, r=0) = i < len(v) ? sum(v, i+1, v[i] + r) : r;
 
 module sockets(widths=[], width = 100) {
-	leftover = width - sum(widths);
-	echo(leftover=leftover, "(should be greater than 0)");
-	for (i = [0:len(widths)-1]) {
-		s = move(widths, i, 0, leftover/(len(widths)-1));
-		translate([widths[0]/2,0,0])
-		translate([s,-widths[i]/2,0])cylinder(h=26, d=widths[i]);
-	}
+  leftover = width - sum(widths);
+  echo(leftover=leftover, "(should be greater than 0)");
+  for (i = [0:len(widths)-1]) {
+    s = move(widths, i, 0, leftover/(len(widths)-1));
+    translate([widths[0]/2,0,0])
+    translate([s,-widths[i]/2,0])cylinder(h=26, d=widths[i]);
+  }
 }

--- a/gridfinity_socket_holder.scad
+++ b/gridfinity_socket_holder.scad
@@ -1,0 +1,43 @@
+include <gridfinity_modules.scad>
+
+part = 3;
+
+if (part == 1) {
+	socket_holder(4, [12,12,12,13,14,16,16,17,21,22], "METRIC", stackable=false);
+} else if (part == 2) {
+	socket_holder(4, [12,13,14,14,16,16,17,18,20,22], "IMPERIAL", stackable=false);
+} else if (part == 3) {
+	socket_holder(4, [12,12,12,12,12,12,13,14,14,16,16], "Imperial < 1/2\"", stackable=true);
+} else if (part == 4) {
+	socket_holder(3, [17,18,20,22,24], "Imperial >= 1/2\"", stackable=true);
+}
+
+
+module socket_holder(num_x=1, widths=[], name="", stackable=false) {
+	difference(){
+		grid_block(num_x, 1, stackable ? 5 : 3);
+		usable_w = 42*num_x - 6;
+		rotate([-45,0,0])translate([-18,-5,0])
+			sockets(widths*1.01, usable_w);
+		rotate([-45,0,0])translate([-18,-23-6,4])
+			cube([usable_w,18,26]);
+		translate([-18,-20,10])rotate([90,0,0])
+			linear_extrude(10)text(name);
+		if(stackable){
+			translate([-18,-18,22])cube([usable_w,42-6,14]);
+		}
+	}
+}
+
+function move(v, i=0, r=0, lo=0) = i > 0 ? move(v, i-1, r+(v[i-1]+v[i])/2, lo) + lo : r;
+function sum(v, i=0, r=0) = i < len(v) ? sum(v, i+1, v[i] + r) : r;
+
+module sockets(widths=[], width = 100) {
+	leftover = width - sum(widths);
+	echo(leftover=leftover, "(should be greater than 0)");
+	for (i = [0:len(widths)-1]) {
+		s = move(widths, i, 0, leftover/(len(widths)-1));
+		translate([widths[0]/2,0,0])
+		translate([s,-widths[i]/2,0])cylinder(h=26, d=widths[i]);
+	}
+}

--- a/gridfinity_socket_holder.scad
+++ b/gridfinity_socket_holder.scad
@@ -1,6 +1,6 @@
 include <gridfinity_modules.scad>
 
-part = 3;
+part = 5;
 
 if (part == 1) {
 	socket_holder(4, [12,12,12,13,14,16,16,17,21,22], "METRIC", stackable=false);
@@ -9,17 +9,22 @@ if (part == 1) {
 } else if (part == 3) {
 	socket_holder(4, [12,12,12,12,12,12,13,14,14,16,16], "Imperial < 1/2\"", stackable=true);
 } else if (part == 4) {
-	socket_holder(3, [17,18,20,22,24], "Imperial >= 1/2\"", stackable=true);
+	socket_holder(3, [17,18,20,22,24], "Imperial >= 1/2\"", stackable=false);
+} else if (part == 5) {
+	socket_holder(4, [12,12,12,13,14,16,16,17,21,22], "Metric >=7mm", stackable=true);
+} else if (part == 6) {
+	socket_holder(2, [12,12,12,12,12,12], "metric<7mm", stackable=false);
 }
 
+function inc(v, a=.6) = [for (i = v) i+a ];
 
 module socket_holder(num_x=1, widths=[], name="", stackable=false) {
 	difference(){
 		grid_block(num_x, 1, stackable ? 5 : 3);
 		usable_w = 42*num_x - 6;
-		rotate([-45,0,0])translate([-18,-5,0])
-			sockets(widths*1.01, usable_w);
-		rotate([-45,0,0])translate([-18,-23-6,4])
+		rotate([-45,0,0])translate([-18,-5,1])
+			sockets(inc(widths,0.6), usable_w);
+		rotate([-45,0,0])translate([-18,-23-6,5])
 			cube([usable_w,18,26]);
 		translate([-18,-20,10])rotate([90,0,0])
 			linear_extrude(10)text(name);


### PR DESCRIPTION
Inspired by Zack's [Socket Holders](https://thangs.com/designer/ZackFreedman/3d-model/Gridfinity%2520Ratchet%2520%252B%2520Socket%2520Holders-60906), parts 1 and 2 might be good replacements for his designs.

My socket set contained 16 metric and 16 imperial sockets, so I created parts 3, 4, 5, and 6, which you see printed. They can be made "stackable", which is handy for carrying or storing tools.

![My socket holders, which are similar to the ones this will create](https://zachdecook.com/sockets.jpg)

The "stackability" depends on the length of the sockets. In the picture, nothing can be stacked on top of the right side of the "Metric >=7mm" bin. This has been modified in the SCAD file by making that taller.

The measurements of each socket were taken with a NEIKO digital caliper (used as a non-digital caliper due to the batteries being dead.
The main issue I fixed in the iterations of this design was tightness for holding the sockets. Because we want to be able to pick out a socket with a single finger (and because openscad underestimates cylinders), I have added 0.6mm to each diameter.

This openscad project automatically spaces the socket holes, and it `echo`s a message about the leftover space (which is spread between the holes). If this leftover space is much less than 0, you should increment the width to use another grid unit.