### PR TITLE
Allow setting of label position to center, round label.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Options for bins:
 * Finger-slide for removing small parts, available as an option
 * Label feature available as an option
 * Label feature can cover entire X length or only part
+* Label feature can be left-justified, right-justified, or centered
 * Magnet/screw hole can have printable overhangs as an option (if screw holes and magnet pockets are both used) (similar in spirit to [this](https://www.printables.com/model/269834-gridfinity-template-modified-for-mid-air-holes))
 * Option for material-efficient floor that is not flat but saves material/time (similar in spirit to [this](https://www.printables.com/model/265271-gridfinity-lite-economical-plain-storage-bins))
 * Fractional-width bins (0.5 units) supported (similar in spirit to [this](https://www.printables.com/model/241907-gridfinity-half-boxes-up-to-3-grids-long-and-6u-hi))

--- a/gridfinity_basic_cup.scad
+++ b/gridfinity_basic_cup.scad
@@ -18,7 +18,7 @@ filled_in = false;
 // X dimension subdivisions
 chambers = 1;
 // Include overhang for labeling
-withLabel = false;
+withLabel = "left"; // ["disabled", "left", "right", "center"]
 // Include larger corner fillet
 fingerslide = true;
 // Width of the label in number of units: positive numbers are measured from the 0 end, negative numbers are measured from the far end, value of zero means full width (as long as withLabel is true)

--- a/gridfinity_basic_cup.scad
+++ b/gridfinity_basic_cup.scad
@@ -17,11 +17,11 @@ hole_overhang_remedy = true;
 filled_in = false;
 // X dimension subdivisions
 chambers = 1;
-// Include overhang for labeling
-withLabel = "left"; // ["disabled", "left", "right", "center"]
+// Include overhang for labeling (and specify left/right/center justification)
+withLabel = "disabled"; // ["disabled", "left", "right", "center"]
 // Include larger corner fillet
 fingerslide = true;
-// Width of the label in number of units: positive numbers are measured from the 0 end, negative numbers are measured from the far end, value of zero means full width (as long as withLabel is true)
+// Width of the label in number of units, or zero means full width
 labelWidth = 0;  // .1
 // Minimum thickness above cutouts in base (Zack's design is effectively 1.2)
 floor_thickness = 0.7;

--- a/gridfinity_cup_modules.scad
+++ b/gridfinity_cup_modules.scad
@@ -4,8 +4,8 @@ include <gridfinity_modules.scad>
 default_chambers = 1;
 
 // Include overhang for labeling
-default_withLabel = "left"; //[disabled: no label, left: left aligned label, right: right aligned label, center: center aligned label]
-// Width of the label in number of units
+default_withLabel = "disabled"; //[disabled: no label, left: left aligned label, right: right aligned label, center: center aligned label]
+// Width of the label in number of units, or zero for full width
 default_labelWidth = 0; // 0.1
 // Include larger corner fillet
 default_fingerslide = true;
@@ -135,7 +135,7 @@ module partitioned_cavity(num_x, num_y, num_z, withLabel=default_withLabel,
     }
     // this is the label
     if (withLabel != "disabled") {
-      label_num_x = labelWidth == 0 ? num_x : labelWidth;
+      label_num_x = labelWidth <= 0 ? num_x : labelWidth;
       label_pos_x = withLabel == "center" ? (num_x - label_num_x) / 2 
                     : withLabel == "right" ? num_x - label_num_x 
                     : 0 ;

--- a/gridfinity_cup_modules.scad
+++ b/gridfinity_cup_modules.scad
@@ -3,11 +3,9 @@ include <gridfinity_modules.scad>
 // X dimension subdivisions
 default_chambers = 1;
 // Include overhang for labeling
-default_withLabel = false;
+default_withLabel = "left"; // ["disabled", "left", "right", "center"]
 // Width of the label in number of units
-// positive numbers are measured from the 0 end
-// negative numbers are measured from the far end
-default_labelWidth = "full";
+default_labelWidth = 0; // 0.1
 // Include larger corner fillet
 default_fingerslide = true;
 // Set magnet diameter and depth to 0 to print without magnet holes
@@ -135,12 +133,20 @@ module partitioned_cavity(num_x, num_y, num_z, withLabel=default_withLabel,
       }
     }
     // this is the label
-    if (withLabel) {
-      label_num_x = (labelWidth == "full" || labelWidth == 0) ? num_x : labelWidth;
-      label_pos_x = label_num_x >= 0 ? 0 : num_x + label_num_x;
+    if (withLabel != "disabled") {
+      label_num_x = labelWidth == 0 ? num_x : labelWidth;
+      label_pos_x = withLabel == "center" ? (num_x - label_num_x) / 2 
+                    : withLabel == "right" ? num_x - label_num_x 
+                    : 0 ;
+
       hull() for (i=[0,1, 2])
       translate([(-gridfinity_pitch/2) + (label_pos_x * gridfinity_pitch), yz[i][0], yz[i][1]])
-      rotate([0, 90, 0]) cylinder(d=bar_d, h=abs(label_num_x)*gridfinity_pitch, $fn=24);
+      rotate([0, 90, 0])
+      union(){
+          tz(abs(label_num_x)*gridfinity_pitch)
+          sphere(d=bar_d, $fn=24);
+          sphere(d=bar_d, $fn=24);
+      }
     }
   }
 }

--- a/gridfinity_cup_modules.scad
+++ b/gridfinity_cup_modules.scad
@@ -2,8 +2,9 @@ include <gridfinity_modules.scad>
 
 // X dimension subdivisions
 default_chambers = 1;
+
 // Include overhang for labeling
-default_withLabel = "left"; // ["disabled", "left", "right", "center"]
+default_withLabel = "left"; //[disabled: no label, left: left aligned label, right: right aligned label, center: center aligned label]
 // Width of the label in number of units
 default_labelWidth = 0; // 0.1
 // Include larger corner fillet


### PR DESCRIPTION
Changed **withLabel** (was boolean) to be a string that allowed setting label position. (left, right, center, disabled).
labelWidth would now only support 0 and positive values.
**withLabel**
- disabled: no label is added.
- left, right, center: label is aligned based on this value.
 
**labelWidth** 
- 0: means full width.
- positive value: number works as before, being based on gridfinity widths.

The labels also now also rounded edges when not against the walls.

![image](https://user-images.githubusercontent.com/2128234/194754634-d9c4c12a-599c-41bd-9951-2e536b2a3764.png)
![image](https://user-images.githubusercontent.com/2128234/194754520-8c462d62-8e11-4c3a-b795-c546db432888.png)
![image](https://user-images.githubusercontent.com/2128234/194754551-6d85e3bd-3ef3-48bd-8ad5-3083c6939df5.png)
![image](https://user-images.githubusercontent.com/2128234/194754579-9075ea74-752c-4104-9d5f-697ac1edda46.png)

