### PR TITLE
Added option to put attachments only in box corners

### DIFF
--- a/gridfinity_basic_cup.scad
+++ b/gridfinity_basic_cup.scad
@@ -6,13 +6,15 @@ width = 2; // [ 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 ]
 // Y dimension in grid units
 depth = 1; // [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 ]
 // Z dimension (multiples of 7mm)
-height = 3;// [2, 3, 4, 5, 6, 7]
+height = 3;
 // (Zack's design uses magnet diameter of 6.5)
 magnet_diameter = 0;  // .1
 // (Zack's design uses depth of 6)
 screw_depth = 0;
 // Hole overhang remedy is active only when both screws and magnets are nonzero (and this option is selected)
 hole_overhang_remedy = true;
+//Only add attachments (magnets and screw) to box corners (prints faster).
+box_corner_attachments_only = false;
 // Fill in solid block (overrides all following options)
 filled_in = false;
 // X dimension subdivisions
@@ -44,7 +46,7 @@ separator_positions = [ 0.25, 0.5, 1.4 ];
 if (filled_in) {
   grid_block(width, depth, height, magnet_diameter=magnet_diameter, 
     screw_depth=screw_depth, hole_overhang_remedy=hole_overhang_remedy,
-    half_pitch=half_pitch);
+    half_pitch=half_pitch, box_corner_attachments_only=box_corner_attachments_only);
 }
 else if (irregular_subdivisions) {
   irregular_cup(
@@ -61,7 +63,8 @@ else if (irregular_subdivisions) {
     hole_overhang_remedy=hole_overhang_remedy,
     separator_positions=separator_positions,
     half_pitch=half_pitch,
-    lip_style=lip_style
+    lip_style=lip_style,
+    box_corner_attachments_only=box_corner_attachments_only
   );
 }
 else {
@@ -80,6 +83,7 @@ else {
     hole_overhang_remedy=hole_overhang_remedy,
     efficient_floor=efficient_floor,
     half_pitch=half_pitch,
-    lip_style=lip_style
+    lip_style=lip_style,
+    box_corner_attachments_only=box_corner_attachments_only
   );
 }

--- a/gridfinity_cup_modules.scad
+++ b/gridfinity_cup_modules.scad
@@ -26,7 +26,8 @@ default_efficient_floor = false;
 default_half_pitch = false;
 // Might want to remove inner lip of cup
 default_lip_style = "normal";
-
+// Limit attachments (magnets and scres) to box corners for faster printing.
+box_corner_attachments_only = false;
 basic_cup(
   num_x=2,
   num_y=1,
@@ -41,7 +42,8 @@ basic_cup(
   hole_overhang_remedy=default_hole_overhang_remedy,
   efficient_floor=default_efficient_floor,
   half_pitch=default_half_pitch,
-  lip_style=default_lip_style
+  lip_style=default_lip_style,
+  box_corner_attachments_only=box_corner_attachments_only
 );
 
 
@@ -63,14 +65,15 @@ module basic_cup(
   hole_overhang_remedy=default_hole_overhang_remedy,
   efficient_floor=default_efficient_floor,
   half_pitch=default_half_pitch,
-  lip_style=default_lip_style  
+  lip_style=default_lip_style,
+  box_corner_attachments_only=box_corner_attachments_only
   ) {
   num_separators = chambers-1;
   sep_pitch = num_x/(num_separators+1);
   separator_positions = num_separators < 1 ? [] : [ for (i=[1:num_separators]) i*sep_pitch ];
   
   difference() {
-    grid_block(num_x, num_y, num_z, magnet_diameter, screw_depth, hole_overhang_remedy=hole_overhang_remedy, half_pitch=half_pitch);
+    grid_block(num_x, num_y, num_z, magnet_diameter, screw_depth, hole_overhang_remedy=hole_overhang_remedy, half_pitch=half_pitch, box_corner_attachments_only=box_corner_attachments_only);
     color("red") partitioned_cavity(num_x, num_y, num_z, withLabel=withLabel,
     labelWidth=labelWidth, fingerslide=fingerslide, magnet_diameter=magnet_diameter, 
     screw_depth=screw_depth, floor_thickness=floor_thickness, wall_thickness=wall_thickness,
@@ -98,7 +101,7 @@ module irregular_cup(
   lip_style=default_lip_style
   ) {
   difference() {
-    grid_block(num_x, num_y, num_z, magnet_diameter, screw_depth, hole_overhang_remedy=hole_overhang_remedy, half_pitch=half_pitch);
+    grid_block(num_x, num_y, num_z, magnet_diameter, screw_depth, hole_overhang_remedy=hole_overhang_remedy, half_pitch=half_pitch, box_corner_attachments_only=box_corner_attachments_only);
     color("red") partitioned_cavity(num_x, num_y, num_z, withLabel=withLabel,
     labelWidth=labelWidth, fingerslide=fingerslide, magnet_diameter=magnet_diameter, 
     screw_depth=screw_depth, floor_thickness=floor_thickness, wall_thickness=wall_thickness,


### PR DESCRIPTION
This option limits the attachments (magnets and screws) to the 4 corners of the box.
This speeds up print time, and slightly reduces the amount of filament. 

Option off, (original)
![image](https://user-images.githubusercontent.com/2128234/202655674-eecbaa58-1c59-4738-af18-5a58d5259afb.png)

Option on
![image](https://user-images.githubusercontent.com/2128234/202655749-21515df6-6cf9-42d0-b25a-f4aee516e035.png)
