### PR TITLE
Allow custom subdivisions to be set in customizer

### DIFF
--- a/gridfinity_basic_cup.scad
+++ b/gridfinity_basic_cup.scad
@@ -7,6 +7,20 @@ width = 2; // [ 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 ]
 depth = 1; // [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 ]
 // Z dimension (multiples of 7mm)
 height = 3;
+// Fill in solid block (overrides all following options)
+filled_in = false;
+// Include overhang for labeling (and specify left/right/center justification)
+withLabel = "disabled"; // ["disabled", "left", "right", "center", "leftchamber", "rightchamber", "centerchamber"]
+// Width of the label in number of units, or zero means full width
+labelWidth = 0;  // .01
+// Wall thickness (Zack's design is 0.95)
+wall_thickness = 0.95;  // .01
+// Remove some or all of lip
+lip_style = "normal";  // [ "normal", "reduced", "none" ]
+
+/* [Base] */
+// Include larger corner fillet
+fingerslide = true;
 // (Zack's design uses magnet diameter of 6.5)
 magnet_diameter = 0;  // .1
 // (Zack's design uses depth of 6)
@@ -15,33 +29,23 @@ screw_depth = 0;
 hole_overhang_remedy = true;
 //Only add attachments (magnets and screw) to box corners (prints faster).
 box_corner_attachments_only = false;
-// Fill in solid block (overrides all following options)
-filled_in = false;
-// X dimension subdivisions
-chambers = 1;
-// Include overhang for labeling (and specify left/right/center justification)
-withLabel = "disabled"; // ["disabled", "left", "right", "center", "leftchamber", "rightchamber", "centerchamber"]
-// Include larger corner fillet
-fingerslide = true;
-// Width of the label in number of units, or zero means full width
-labelWidth = 0;  // .01
 // Minimum thickness above cutouts in base (Zack's design is effectively 1.2)
 floor_thickness = 0.7;
-// Wall thickness (Zack's design is 0.95)
-wall_thickness = 0.95;  // .01
 // Efficient floor option saves material and time, but the floor is not smooth (only applies if no magnets, screws, or finger-slide used)
 efficient_floor = false;
-// When enabled, irregular subdivisions have to be defined in code
-irregular_subdivisions = false;
 // Enable to subdivide bottom pads to allow half-cell offsets
 half_pitch = false;
-// Remove some or all of lip
-lip_style = "normal";  // [ "normal", "reduced", "none" ]
+
+/* [Subdivisions] */
+// X dimension subdivisions
+chambers = 1;
+// Enable irregular subdivisions
+irregular_subdivisions = false;
+// Separator positions are defined in terms of grid units from the left end
+separator_positions = [ 0.25, 0.5, 1, 1.33, 1.66];
+
 
 module end_of_customizer_opts() {}
-
-// Separator positions are defined in terms of grid units from the left end
-separator_positions = [ 0.25, 0.5, 1.4 ];
 
 if (filled_in) {
   grid_block(width, depth, height, magnet_diameter=magnet_diameter, 


### PR DESCRIPTION
Small change to allow the custom Subdivisions to be set in the customers. Need 5 values so a text field is rendered, but it can be edited.
re-submitted due to conflicts.

![image](https://user-images.githubusercontent.com/2128234/224686312-8b8d7146-0b59-4624-8fa5-4becf55f9166.png)
