### PR TITLE
Added option for a flat base.

### DIFF
--- a/gridfinity_basic_cup.scad
+++ b/gridfinity_basic_cup.scad
@@ -38,6 +38,8 @@ half_pitch = false;
 // Remove some or all of lip
 lip_style = "normal";  // [ "normal", "reduced", "none" ]
 
+// Removes the base grid from inside the shape
+flat_base = false;
 module end_of_customizer_opts() {}
 
 // Separator positions are defined in terms of grid units from the left end
@@ -46,7 +48,7 @@ separator_positions = [ 0.25, 0.5, 1.4 ];
 if (filled_in) {
   grid_block(width, depth, height, magnet_diameter=magnet_diameter, 
     screw_depth=screw_depth, hole_overhang_remedy=hole_overhang_remedy,
-    half_pitch=half_pitch, box_corner_attachments_only=box_corner_attachments_only);
+    half_pitch=half_pitch, box_corner_attachments_only=box_corner_attachments_only,flat_base = flat_base);
 }
 else if (irregular_subdivisions) {
   irregular_cup(
@@ -64,7 +66,8 @@ else if (irregular_subdivisions) {
     separator_positions=separator_positions,
     half_pitch=half_pitch,
     lip_style=lip_style,
-    box_corner_attachments_only=box_corner_attachments_only
+    box_corner_attachments_only=box_corner_attachments_only,
+    flat_base = flat_base
   );
 }
 else {
@@ -84,6 +87,7 @@ else {
     efficient_floor=efficient_floor,
     half_pitch=half_pitch,
     lip_style=lip_style,
-    box_corner_attachments_only=box_corner_attachments_only
+    box_corner_attachments_only=box_corner_attachments_only,
+    flat_base = flat_base
   );
 }

--- a/gridfinity_modules.scad
+++ b/gridfinity_modules.scad
@@ -9,7 +9,7 @@ sharp_corners = 0;
 
 // basic block with cutout in top to be stackable, optional holes in bottom
 // start with this and begin 'carving'
-module grid_block(num_x=1, num_y=1, num_z=2, magnet_diameter=6.5, screw_depth=6, center=false, hole_overhang_remedy=false, half_pitch=false, box_corner_attachments_only = false) {
+module grid_block(num_x=1, num_y=1, num_z=2, magnet_diameter=6.5, screw_depth=6, center=false, hole_overhang_remedy=false, half_pitch=false, box_corner_attachments_only = false, flat_base=false) {
   corner_radius = 3.75;
   outer_size = gridfinity_pitch - gridfinity_clearance;  // typically 41.5
   block_corner_position = outer_size/2 - corner_radius;  // need not match center of pad corners
@@ -32,7 +32,7 @@ module grid_block(num_x=1, num_y=1, num_z=2, magnet_diameter=6.5, screw_depth=6,
     intersection() {
       union() {
         // logic for constructing odd-size grids of possibly half-pitch pads
-        pad_grid(num_x, num_y, half_pitch);
+        pad_grid(num_x, num_y, half_pitch, flat_base);
         // main body will be cut down afterward
         translate([-gridfinity_pitch/2, -gridfinity_pitch/2, 5]) 
         cube([gridfinity_pitch*num_x, gridfinity_pitch*num_y, totalht-5]);
@@ -72,7 +72,7 @@ module grid_block(num_x=1, num_y=1, num_z=2, magnet_diameter=6.5, screw_depth=6,
 }
 
 
-module pad_grid(num_x, num_y, half_pitch=false) {
+module pad_grid(num_x, num_y, half_pitch=false, flat_base=false) {
   // if num_x (or num_y) is less than 1 (or less than 0.5 if half_pitch is enabled) then round over the far side
   cut_far_x = (num_x < 1 && !half_pitch) || (num_x < 0.5);
   cut_far_y = (num_y < 1 && !half_pitch) || (num_y < 0.5);
@@ -91,6 +91,19 @@ module pad_grid(num_x, num_y, half_pitch=false) {
         translate([gridfinity_pitch*(-0.5+num_x), gridfinity_pitch*(-0.5+num_y), 0]) pad_halfsize();
       }
     }
+  }
+  else if (flat_base) {
+      pad_oversize(ceil(num_x), ceil(num_y));
+      if (cut_far_x) {
+        translate([gridfinity_pitch*(-1+num_x), 0, 0]) pad_oversize();
+      }
+      if (cut_far_y) {
+        translate([0, gridfinity_pitch*(-1+num_y), 0]) pad_oversize();
+      }
+      if (cut_far_x && cut_far_y) {
+        // without this the far corner would be rectangular
+        translate([gridfinity_pitch*(-1+num_x), gridfinity_pitch*(-1+num_y), 0]) pad_oversize();
+      }
   }
   else {
     gridcopy(ceil(num_x), ceil(num_y)) intersection() {


### PR DESCRIPTION
Added new option for a flat base. This removes the internal grid from the bottom, so would not be compatible with using a base grid.
When used efficient base, it uses a similar amount of material but give a flat internal base.
It might be suitable for making a lid/catch all tray, 

![image](https://user-images.githubusercontent.com/2128234/224700607-1b09d792-29ec-4fd7-b29e-df16109752c2.png)

