### PR TITLE
Remove floor fillet for efloor mode [1]

### DIFF
--- a/gridfinity_cup_modules.scad
+++ b/gridfinity_cup_modules.scad
@@ -75,7 +75,7 @@ module basic_cup(
   difference() {
     grid_block(num_x, num_y, num_z, magnet_diameter, screw_depth, hole_overhang_remedy=hole_overhang_remedy, half_pitch=half_pitch, box_corner_attachments_only=box_corner_attachments_only);
     color("red") partitioned_cavity(num_x, num_y, num_z, withLabel=withLabel,
-    labelWidth=labelWidth, fingerslide=fingerslide, magnet_diameter=magnet_diameter, 
+    labelWidth=labelWidth, fingerslide=fingerslide, magnet_diameter=magnet_diameter,
     screw_depth=screw_depth, floor_thickness=floor_thickness, wall_thickness=wall_thickness,
     efficient_floor=efficient_floor, separator_positions=separator_positions, lip_style=lip_style);
   }
@@ -288,6 +288,12 @@ module basic_cavity(num_x, num_y, num_z, fingerslide=default_fingerslide,
       gridcopy(num_x, num_y) hull() {
         tz(3) cornercopy(seventeen-0.5) cylinder(r=1, h=1, $fn=32);
         tz(5-(+2.5-1.15-q)) cornercopy(seventeen) cylinder(r=1.15+q, h=4, $fn=32);
+      }
+      
+      // cleanup floor difference overhangs
+      hull()
+      cornercopy(seventeen, num_x, num_y) {
+        tz(floorht) cylinder(d=2.3+2*q, h=2.3+2*q, $fn=24);
       }
     }
   }


### PR DESCRIPTION
Hi Jamie.

This is my first attempt to contributing to the project to get more familiar with it.

Maybe it's just my personal taste, so feel free to reject this PR.

In `efloor` mode, you dig the standard floor which has a spherical fillet, but I'm not sure a filleted floor inner edge is functional in this case.
In my opinion, a sharpen inner edge might be more effective.


To try the change, in `gridfinity_basic_cup.scad`, set:

```
depth = 2;
fingerslide = false;
efficient_floor = true;
```



Thanks for your job.
