### PR TITLE
Enable efloor+fingerslide options [3]

### DIFF
--- a/gridfinity_cup_modules.scad
+++ b/gridfinity_cup_modules.scad
@@ -75,7 +75,7 @@ module basic_cup(
   difference() {
     grid_block(num_x, num_y, num_z, magnet_diameter, screw_depth, hole_overhang_remedy=hole_overhang_remedy, half_pitch=half_pitch, box_corner_attachments_only=box_corner_attachments_only);
     color("red") partitioned_cavity(num_x, num_y, num_z, withLabel=withLabel,
-    labelWidth=labelWidth, fingerslide=fingerslide, magnet_diameter=magnet_diameter, 
+    labelWidth=labelWidth, fingerslide=fingerslide, magnet_diameter=magnet_diameter,
     screw_depth=screw_depth, floor_thickness=floor_thickness, wall_thickness=wall_thickness,
     efficient_floor=efficient_floor, separator_positions=separator_positions, lip_style=lip_style);
   }
@@ -288,6 +288,12 @@ module basic_cavity(num_x, num_y, num_z, fingerslide=default_fingerslide,
       gridcopy(num_x, num_y) hull() {
         tz(3) cornercopy(seventeen-0.5) cylinder(r=1, h=1, $fn=32);
         tz(5-(+2.5-1.15-q)) cornercopy(seventeen) cylinder(r=1.15+q, h=4, $fn=32);
+      }
+      
+      // cleanup floor difference overhangs
+      hull()
+      cornercopy(seventeen, num_x, num_y) {
+        tz(floorht) cylinder(d=2.3+2*q, h=2.3+2*q, $fn=24);
       }
     }
   }

--- a/gridfinity_modules.scad
+++ b/gridfinity_modules.scad
@@ -195,14 +195,18 @@ module gridcopycorners(num_x, num_y, r, onlyBoxCorners = false) {
 
 // similar to quadtranslate but expands to extremities of a block
 module cornercopy(r, num_x=1, num_y=1) {
-  for (xx=[-r, gridfinity_pitch*(num_x-1)+r]) for (yy=[-r, gridfinity_pitch*(num_y-1)+r]) 
+  for (xx=[-r, gridfinity_pitch*(num_x-1)+r]) for (yy=[-r, gridfinity_pitch*(num_y-1)+r])
     translate([xx, yy, 0]) children();
 }
 
 
 // make repeated copies of something(s) at the gridfinity spacing of 42mm
-module gridcopy(num_x, num_y) {
-  for (xi=[1:num_x]) for (yi=[1:num_y]) translate([gridfinity_pitch*(xi-1), gridfinity_pitch*(yi-1), 0]) children();
+module gridcopy(num_x, num_y, half_pitch=default_half_pitch) {
+  if (half_pitch) {
+    for (xi=[1:num_x*2]) for (yi=[1:num_y*2]) translate([gridfinity_pitch/2*(xi-1.5), gridfinity_pitch/2*(yi-1.5), 0]) children();
+  } else {
+    for (xi=[1:num_x]) for (yi=[1:num_y]) translate([gridfinity_pitch*(xi-1), gridfinity_pitch*(yi-1), 0]) children();
+  }
 }
 
 


### PR DESCRIPTION
Hi Jamie,

I thought it would be useful to have both the `efficient_floor` and `fingerslide` options enabled together, but I noticed you had prevented this. I checked if there were any issues with allowing it, and it seems to work.

Maybe that difference-union-difference-union part should be refactored, but... one step at a time.