### PR TITLE
Enable base plates to be CNC'd with 1/4" bits by modding bottom most corner radius to 3.175mm (Rough POC edits for feedback...)

### DIFF
--- a/gridfinity_cup_modules.scad
+++ b/gridfinity_cup_modules.scad
@@ -28,6 +28,12 @@ default_half_pitch = false;
 default_lip_style = "normal";
 // Limit attachments (magnets and scres) to box corners for faster printing.
 box_corner_attachments_only = false;
+// Label recess depth, use to increase tolerance for top of label.  Useful if printing 
+// gridfinity cubes when printer tuning and experiencing poor cooling resulting in lift 
+// or warping, but still want a usable cube.
+// Zack's design is 0mm
+label_recess = 1.5;
+
 basic_cup(
   num_x=2,
   num_y=1,
@@ -74,10 +80,21 @@ module basic_cup(
   
   difference() {
     grid_block(num_x, num_y, num_z, magnet_diameter, screw_depth, hole_overhang_remedy=hole_overhang_remedy, half_pitch=half_pitch, box_corner_attachments_only=box_corner_attachments_only);
-    color("red") partitioned_cavity(num_x, num_y, num_z, withLabel=withLabel,
-    labelWidth=labelWidth, fingerslide=fingerslide, magnet_diameter=magnet_diameter, 
-    screw_depth=screw_depth, floor_thickness=floor_thickness, wall_thickness=wall_thickness,
-    efficient_floor=efficient_floor, separator_positions=separator_positions, lip_style=lip_style);
+    color("red") 
+    partitioned_cavity(
+      num_x,
+      num_y,
+      num_z,
+      withLabel=withLabel,
+      labelWidth=labelWidth,
+      fingerslide=fingerslide,
+      magnet_diameter=magnet_diameter, 
+      screw_depth=screw_depth,
+      floor_thickness=floor_thickness,
+      wall_thickness=wall_thickness,
+      efficient_floor=efficient_floor,
+      separator_positions=separator_positions,
+      lip_style=lip_style);
   }
 }
 
@@ -100,6 +117,7 @@ module irregular_cup(
   separator_positions=[],
   lip_style=default_lip_style
   ) {
+		
   difference() {
     grid_block(num_x, num_y, num_z, magnet_diameter, screw_depth, hole_overhang_remedy=hole_overhang_remedy, half_pitch=half_pitch, box_corner_attachments_only=box_corner_attachments_only);
     color("red") partitioned_cavity(num_x, num_y, num_z, withLabel=withLabel,
@@ -110,11 +128,21 @@ module irregular_cup(
 }
 
 
-module partitioned_cavity(num_x, num_y, num_z, withLabel=default_withLabel, 
-    labelWidth=default_labelWidth, fingerslide=default_fingerslide, 
-    magnet_diameter=default_magnet_diameter, screw_depth=default_screw_depth, 
-    floor_thickness=default_floor_thickness, wall_thickness=default_wall_thickness,
-    efficient_floor=default_efficient_floor, separator_positions=[], lip_style=default_lip_style) {
+module partitioned_cavity(
+  num_x,
+  num_y,
+  num_z,
+  withLabel=default_withLabel, 
+  labelWidth=default_labelWidth,
+  fingerslide=default_fingerslide, 
+  magnet_diameter=default_magnet_diameter,
+  screw_depth=default_screw_depth, 
+  floor_thickness=default_floor_thickness,
+  wall_thickness=default_wall_thickness,
+  efficient_floor=default_efficient_floor,
+  separator_positions=[],
+  lip_style=default_lip_style) {
+		
   // cavity with removed segments so that we leave dividing walls behind
   gp = gridfinity_pitch;
   outer_wall_th = 1.8;  // cavity is this far away from the 42mm 'ideal' block
@@ -131,9 +159,17 @@ module partitioned_cavity(num_x, num_y, num_z, withLabel=default_withLabel,
   cavity_xsize = gp*num_x-2*outer_wall_th;
 
   difference() {
-    basic_cavity(num_x, num_y, num_z, fingerslide=fingerslide, magnet_diameter=magnet_diameter,
-    screw_depth=screw_depth, floor_thickness=floor_thickness, wall_thickness=wall_thickness,
-    efficient_floor=efficient_floor, lip_style=lip_style);
+    basic_cavity(
+      num_x,
+      num_y,
+      num_z,
+      fingerslide=fingerslide,
+      magnet_diameter=magnet_diameter,
+      screw_depth=screw_depth,
+      floor_thickness=floor_thickness,
+      wall_thickness=wall_thickness,
+      efficient_floor=efficient_floor,
+      lip_style=lip_style);
     
     if (len(separator_positions) > 0) {
       for (i=[0:len(separator_positions)-1]) {
@@ -161,7 +197,10 @@ module partitioned_cavity(num_x, num_y, num_z, withLabel=default_withLabel,
                         : 0 ;
 
         hull() for (i=[0,1, 2])
-        translate([(-gridfinity_pitch/2) + ((chamberStart + label_pos_x) * gridfinity_pitch), yz[i][0], yz[i][1]])
+        translate([
+          (-gridfinity_pitch/2) + ((chamberStart + label_pos_x) * gridfinity_pitch),
+          yz[i][0],
+          -label_recess + yz[i][1]])
         rotate([0, 90, 0])
         union(){
             tz(abs(label_num_x)*gridfinity_pitch)
@@ -174,10 +213,18 @@ module partitioned_cavity(num_x, num_y, num_z, withLabel=default_withLabel,
 }
 
 
-module basic_cavity(num_x, num_y, num_z, fingerslide=default_fingerslide, 
-    magnet_diameter=default_magnet_diameter, screw_depth=default_screw_depth, 
-    floor_thickness=default_floor_thickness, wall_thickness=default_wall_thickness,
-    efficient_floor=default_efficient_floor, lip_style=default_lip_style) {
+module basic_cavity(
+  num_x,
+  num_y,
+  num_z,
+  fingerslide=default_fingerslide, 
+  magnet_diameter=default_magnet_diameter,
+  screw_depth=default_screw_depth,
+  floor_thickness=default_floor_thickness,
+  wall_thickness=default_wall_thickness,
+  efficient_floor=default_efficient_floor,
+  lip_style=default_lip_style) {
+
   eps = 0.1;
   // I couldn't think of a good name for this ('q') but effectively it's the
   // size of the overhang that produces a wall thickness that's less than the lip

--- a/gridfinity_modules.scad
+++ b/gridfinity_modules.scad
@@ -38,7 +38,7 @@ module grid_block(num_x=1, num_y=1, num_z=2, magnet_diameter=6.5, screw_depth=6,
         cube([gridfinity_pitch*num_x, gridfinity_pitch*num_y, totalht-5]);
       }
       
-      // crop with outer cylinders
+      // crop outer corners with outer cylinders
       translate([0, 0, -0.1])
       hull() 
       cornercopy(block_corner_position, num_x, num_y) 
@@ -46,9 +46,9 @@ module grid_block(num_x=1, num_y=1, num_z=2, magnet_diameter=6.5, screw_depth=6,
     }
     
     // remove top so XxY can fit on top
-      color("blue") 
-      translate([0, 0, gridfinity_zpitch*num_z]) 
-      pad_oversize(num_x, num_y, 1);
+    color("blue") 
+    translate([0, 0, gridfinity_zpitch*num_z]) 
+    pad_oversize(num_x, num_y, 1);
     
     if (esd > 0) {  // add pockets for screws if requested
       gridcopycorners(ceil(num_x), ceil(num_y), magnet_position, box_corner_attachments_only)
@@ -146,28 +146,32 @@ module pad_oversize(num_x=1, num_y=1, margins=0) {
   radialgap = margins ? 0.25 : 0;  // oversize cylinders for a bit of clearance
   axialdown = margins ? 0.1 : 0;   // a tiny bit of axial clearance present in Zack's design
   
+  small_radius = 1.6;
+  med_radius = small_radius * 2;
+  big_radius = med_radius * 2.34375;
+	
   translate([0, 0, -axialdown])
   difference() {
     union() {
       hull() cornercopy(pad_corner_position, num_x, num_y) {
         if (sharp_corners) {
-          cylsq(d=1.6+2*radialgap, h=0.1);
-          translate([0, 0, bevel1_top]) cylsq(d=3.2+2*radialgap, h=1.9);
+          cylsq(d=small_radius+2*radialgap, h=0.1);
+          translate([0, 0, bevel1_top]) cylsq(d=med_radius+2*radialgap, h=1.9);
         }
         else {
-          cylinder(d=1.6+2*radialgap, h=0.1, $fn=24);
-          translate([0, 0, bevel1_top]) cylinder(d=3.2+2*radialgap, h=1.9, $fn=32);
+          cylinder(d=small_radius+2*radialgap, h=0.1, $fn=24);
+          translate([0, 0, bevel1_top]) cylinder(d=med_radius+2*radialgap, h=1.9, $fn=32);
         }
       }
       
       hull() cornercopy(pad_corner_position, num_x, num_y) {
         if (sharp_corners) {
           translate([0, 0, bevel2_bottom]) 
-          cylsq2(d1=3.2+2*radialgap, d2=7.5+0.5+2*radialgap+2*bonus_ht, h=bevel2_top-bevel2_bottom+bonus_ht);
+          cylsq2(d1=med_radius+2*radialgap, d2=big_radius+0.5+2*radialgap+2*bonus_ht, h=bevel2_top-bevel2_bottom+bonus_ht);
         }
         else {
           translate([0, 0, bevel2_bottom]) 
-          cylinder(d1=3.2+2*radialgap, d2=7.5+0.5+2*radialgap+2*bonus_ht, h=bevel2_top-bevel2_bottom+bonus_ht, $fn=32);
+          cylinder(d1=med_radius+2*radialgap, d2=big_radius+0.5+2*radialgap+2*bonus_ht, h=bevel2_top-bevel2_bottom+bonus_ht, $fn=32);
         }
       }
     }

--- a/gridfinity_modules.scad
+++ b/gridfinity_modules.scad
@@ -145,35 +145,60 @@ module pad_oversize(num_x=1, num_y=1, margins=0) {
   // female parts are a bit oversize for a nicer fit
   radialgap = margins ? 0.25 : 0;  // oversize cylinders for a bit of clearance
   axialdown = margins ? 0.1 : 0;   // a tiny bit of axial clearance present in Zack's design
-  
+
   small_radius = 1.6;
-  med_radius = small_radius * 2;
-  big_radius = med_radius * 2.34375;
-	
+  med_radius = 3.2;
+  big_radius = 7.5;
+  block_corner_outer_radius = big_radius;
+
+  // Use to enable containers to fit trays CNC carved with 1/4" bit
+  bottom_radius = margins ? small_radius : 3.175;
+  bottom_radius_offset = (bottom_radius - small_radius) / 2;
+  	
   translate([0, 0, -axialdown])
   difference() {
     union() {
+      // Pad upper taper
+      color("purple")
       hull() cornercopy(pad_corner_position, num_x, num_y) {
+        if (sharp_corners) {
+          translate([0, 0, bevel2_bottom]) 
+          cylsq2(d1=med_radius+2*radialgap, d2=block_corner_outer_radius+0.5+2*radialgap+2*bonus_ht, h=bevel2_top-bevel2_bottom+bonus_ht);
+        }
+        else {
+          translate([0, 0, bevel2_bottom]) 
+          cylinder(d1=med_radius+2*radialgap, d2=block_corner_outer_radius+0.5+2*radialgap+2*bonus_ht, h=bevel2_top-bevel2_bottom+bonus_ht, $fn=32);
+        }
+      }
+      
+      // Pad mid vertical
+      color("blue")
+      hull() 
+      cornercopy(pad_corner_position, num_x, num_y) 
+      {
         if (sharp_corners) {
           cylsq(d=small_radius+2*radialgap, h=0.1);
           translate([0, 0, bevel1_top]) cylsq(d=med_radius+2*radialgap, h=1.9);
         }
         else {
-          cylinder(d=small_radius+2*radialgap, h=0.1, $fn=24);
           translate([0, 0, bevel1_top]) cylinder(d=med_radius+2*radialgap, h=1.9, $fn=32);
         }
       }
-      
-      hull() cornercopy(pad_corner_position, num_x, num_y) {
-        if (sharp_corners) {
-          translate([0, 0, bevel2_bottom]) 
-          cylsq2(d1=med_radius+2*radialgap, d2=big_radius+0.5+2*radialgap+2*bonus_ht, h=bevel2_top-bevel2_bottom+bonus_ht);
+
+      // Pad lower taper
+      color("green")
+      hull()
+      union()
+      {
+        cornercopy(pad_corner_position, num_x, num_y) 
+        {
+          translate([0, 0, bevel1_top]) cylinder(d=med_radius+2*radialgap, h=0.1, $fn=32);
         }
-        else {
-          translate([0, 0, bevel2_bottom]) 
-          cylinder(d1=med_radius+2*radialgap, d2=big_radius+0.5+2*radialgap+2*bonus_ht, h=bevel2_top-bevel2_bottom+bonus_ht, $fn=32);
+        cornercopy(pad_corner_position - bottom_radius_offset, num_x, num_y) 
+        {  
+          cylinder(d=bottom_radius+2*radialgap, h=bevel1_top, $fn=32);
         }
-      }
+      }          
     }
     
     // cut off bottom if we're going to go negative


### PR DESCRIPTION
Thoughts on minor edit to make gridfinity printed parts more compatible with base plates that are CNC pocket milled using 1/4" bit?  This small deviation from the official Zack design would allow base plates to be milled faster/cleaner than using 1/8" bits currently needed.

e.g. Round the base pad's lowest corners slightly to 3.175mm radius instead of 1.6mm...

![image](https://github.com/user-attachments/assets/6cf79c03-f11b-4283-b5b4-c427106ee65d)

This is incomplete, am sharing for initial thoughts/feedback.  e.g. I still need to check all callers/references of edited module pad_oversize().